### PR TITLE
Fix compilation error (C-style string functions)

### DIFF
--- a/mazetool.cpp
+++ b/mazetool.cpp
@@ -27,7 +27,7 @@
 
 #include <cstdlib>
 #include <cstdio>
-#include <string>
+#include <cstring>
 #include <getopt.h>
 #include <libgen.h>
 #include <iostream>


### PR DESCRIPTION
I had to change this include in order to be able to compile the project. Please, check that it works well for you too.

The reason behind this change is that you are using C-style string functions, [which are defined in `cstring` header](https://stackoverflow.com/questions/12824595/difference-between-cstring-and-string).